### PR TITLE
Convert integers to usize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,17 @@ pub mod utils {
     use rand::Rng;
     use rand::prelude::SliceRandom;
 
-    fn plot_x_vs_y(data: &Array2<f64>) -> Result<(), Box<dyn std::error::Error>> {
+    fn plot_x_vs_y(
+        data: &Array2<f64>,
+        output_path: &std::path::Path,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         if data.ncols() < 2 {
             return Err(From::from(
                 "Data for plot_x_vs_y must have at least 2 columns.",
             ));
         }
 
-        let root = BitMapBackend::new("xy_scatter_plot.png", (640, 480)).into_drawing_area();
+        let root = BitMapBackend::new(output_path, (640, 480)).into_drawing_area();
         root.fill(&WHITE)?;
 
         // 1. Prepare data and determine axis bounds
@@ -147,6 +150,7 @@ pub mod utils {
         n_iterations: usize,
         n_dim: usize,
         plot: bool,
+        output_path: &std::path::Path,
     ) -> Array2<f64> {
         let mut best_metric = f64::INFINITY;
         let mut best_lhd = Array2::from_elem((n_samples, n_dim), 0.0);
@@ -157,7 +161,7 @@ pub mod utils {
                 best_lhd = lhd.clone();
                 best_metric = maxpro_metric;
                 if plot {
-                    let _ = plot_x_vs_y(&best_lhd);
+                    let _ = plot_x_vs_y(&best_lhd, &output_path);
                 }
                 println!("Best metric: {best_metric}")
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ struct Args {
     plot: bool,
     #[arg(short, long)]
     ndims: usize,
+    #[arg(short, long)]
+    output_path: String,
 }
 
 fn main() {
@@ -20,6 +22,11 @@ fn main() {
     let n_iterations = args.iterations;
     let n_dims = args.ndims;
     let plot = args.plot;
-    let maxpro_lhd = build_maxpro_lhd(n_samples, n_iterations, n_dims, plot);
+    let mut output_path = std::path::Path::new("./");
+    if args.plot {
+        // Assign the variable iff args.plot is used
+        output_path = std::path::Path::new(&args.output_path);
+    }
+    let maxpro_lhd = build_maxpro_lhd(n_samples, n_iterations, n_dims, plot, &output_path);
     println!("{:?}", maxpro_lhd)
 }


### PR DESCRIPTION
i32s were chosen for no clear reason, meaning that casting had to be done in multiple locations. Expect types as usize and bypass this. Minor cleanup and making output path configurable as bonus.