### PR TITLE
Upgrade PyO3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ rayon = "1.11.0"
 plotters = "0.3"
 
 [dependencies.pyo3]
-version = "0.27" # Use your version
-optional = true   # PyO3 is now an optional dependency
+version = "0.27" 
+optional = true 
 features = ["extension-module"]
 
 [features]


### PR DESCRIPTION
PyO3 had the following cargo audit failure:

```
Crate:     pyo3
Version:   0.21.2
Title:     Risk of buffer overflow in `PyString::from_object`
Date:      2025-04-01
ID:        RUSTSEC-2025-0020
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0020
Solution:  Upgrade to >=0.24.1
Dependency tree:
```
Upgrading to 0.27

Tested cargo build and maturin develop