### PR TITLE
[actions] add fontconfig and system deps step

### DIFF
--- a/.github/workflows/rust-build-test.yml
+++ b/.github/workflows/rust-build-test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install system dependencies
-      run: sudo apt update && sudo apt install -y fontconfig
+      run: sudo apt update && sudo apt install -y libfontconfig1-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
Cargo build failing due to github actions missing a system dependency, adds this to the GitHub action.