### PR TITLE
Coordinate swap annealing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ default = []
 pyo3-bindings = ["dep:pyo3"]
 debug = ["dep:plotters"]
 
+[profile.profiling]
+inherits = "release"
+debug = true

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ to this implementation's simplistic annealing approach as of v0.1.1.
 Benchmarks below can be reproduced [here](https://colab.research.google.com/drive/1-cgXaP92jp1tPd3w7SQtVEr2WJogOM3u?usp=sharing) with source for local reproduction, including R design generation, in `python/comparison_r.py`.
 ```
 R calculation: 95.98506 
-Rust calculation: 95.98505099515629
-Design with metric 92.61901238146892 found in 22.75386095046997 seconds
-Rust/R runtime ratio: 4.134247573875547
+Rust calculation: 95.98505099515626
+Design with metric 92.61063616523754 found in 12.107218980789185 seconds
+Rust/R runtime ratio: 2.1998130693803777
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Benchmarks below can be reproduced [here](https://colab.research.google.com/driv
 ```
 R calculation: 95.98506 
 Rust calculation: 95.98505099515626
-Design with metric 92.61063616523754 found in 12.107218980789185 seconds
-Rust/R runtime ratio: 2.1998130693803777
+Design with metric 92.61063616523754 found in 10.24436092376709 seconds
+Rust/R runtime ratio: 1.8613423184391384
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ Maximin design and optimization is benchmarked against PyDOE3 as the reference i
 
 
 Benchmarks are run with `python/comparisons.py`.
-Last PR's benchmarks:
+Last PR's benchmarks, with `maturin develop --features pyo3-bindings --release` to build locally:
 ```
-Rust calculation: 72.39111811323957 in 0.6073048114776611 s
-Python calculation: 91.68853790868829 in 24.695823907852173 s
-Python / Rust ratio: 40.66462745085723
+Rust calculation: 72.39111811323956 in 0.04288196563720703 s
+Python calculation: 88.08540472310199 in 25.065167903900146 s
+Python / Rust ratio: 584.5153675080618
 Benchmarking Maximin time against reference implementation
-Rust criterion 0.22187155920586812 in 1.256173849105835 s
-Python criterion 0.21981200135003268 in 0.07808876037597656 s
-Python/Rust ratio: 0.062163975497150664
+Rust criterion 0.22187155920586812 in 0.02629995346069336 s
+Python criterion 0.21743947754068282 in 0.0779728889465332 s
+Python/Rust ratio: 2.9647538754419362
 ```
 
 The MaxPro metric calculation can be differentially tested against the R package as the source of truth. 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ Maximin design and optimization is benchmarked against PyDOE3 as the reference i
 Benchmarks are run with `python/comparisons.py`.
 Last PR's benchmarks:
 ```
-Rust calculation: 72.39111811323957 in 0.016954898834228516 s
-Python calculation: 89.75996904868765 in 25.15124797821045 s
-Python / Rust ratio: 1483.4207047838681
+Rust calculation: 72.39111811323957 in 0.6073048114776611 s
+Python calculation: 91.68853790868829 in 24.695823907852173 s
+Python / Rust ratio: 40.66462745085723
 Benchmarking Maximin time against reference implementation
-Rust criterion 0.22187155920586812 in 0.02622389793395996 s
-Python criterion 0.21295020774372542 in 0.07755494117736816 s
-Python/Rust ratio: 2.9574146975661644
+Rust criterion 0.22187155920586812 in 1.256173849105835 s
+Python criterion 0.21981200135003268 in 0.07808876037597656 s
+Python/Rust ratio: 0.062163975497150664
 ```
 
 The MaxPro metric calculation can be differentially tested against the R package as the source of truth. 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ Maximin design and optimization is benchmarked against PyDOE3 as the reference i
 Benchmarks are run with `python/comparisons.py`.
 Last PR's benchmarks, with `maturin develop --features pyo3-bindings --release` to build locally:
 ```
-Rust calculation: 72.39111811323956 in 0.04288196563720703 s
-Python calculation: 88.08540472310199 in 25.065167903900146 s
-Python / Rust ratio: 584.5153675080618
+Rust calculation: 72.39111811323956 in 0.0381779670715332 s
+Python calculation: 93.14236082134553 in 25.153131008148193 s
+Python / Rust ratio: 658.8389308686692
 Benchmarking Maximin time against reference implementation
-Rust criterion 0.22187155920586812 in 0.02629995346069336 s
-Python criterion 0.21743947754068282 in 0.0779728889465332 s
-Python/Rust ratio: 2.9647538754419362
+Rust criterion 0.22187155920586812 in 0.026096105575561523 s
+Python criterion 0.22642738855220698 in 0.0776219367980957 s
+Python/Rust ratio: 2.9744643917591707
 ```
 
 The MaxPro metric calculation can be differentially tested against the R package as the source of truth. 
@@ -92,14 +92,12 @@ Current comparisons show agreement up to a relative tolerance of 1e-7.
 
 Design generation can also be benchmarked for speed and metric value. A comparison of metric calculation
 is shown below for the same design, as well as design generation with approximately matching parameters.
-The R implementation presently generates a more optimal design than this implementation due in part
-to this implementation's simplistic annealing approach as of v0.1.1.
 
 Benchmarks below can be reproduced [here](https://colab.research.google.com/drive/1-cgXaP92jp1tPd3w7SQtVEr2WJogOM3u?usp=sharing) with source for local reproduction, including R design generation, in `python/comparison_r.py`.
 ```
 R calculation: 95.98506 
 Rust calculation: 95.98505099515626
-Design with metric 92.61063616523754 found in 10.24436092376709 seconds
-Rust/R runtime ratio: 1.8613423184391384
+Design with metric 94.60228692529198 found in 1.3302018642425537 seconds
+Rust/R runtime ratio: 0.24169013961983982
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Benchmarks below can be reproduced [here](https://colab.research.google.com/driv
 ```
 R calculation: 95.98506 
 Rust calculation: 95.98505099515629
-Design with metric 136.20062378481447 found in 3.3881406784057617 seconds
-Rust/R runtime ratio: 0.6156059584849821
+Design with metric 92.61901238146892 found in 22.75386095046997 seconds
+Rust/R runtime ratio: 4.134247573875547
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,8 @@ Usage of this code should cite both this package as implementation and the MaxPr
 - **Generate a random Latin Hypercube**: Create random LHDs with configurable samples and dimensions
 - **MaxPro Optimization**: Generate many random LHDs and return the one that minimizes the MaxPro criterion
 - **Maximin Optimization**: Generate many random LHDs and return the one that maximizes the minimum distance between points
-- **Simulated Annealing**: Further optimize any design using simulated annealing
+- **Simulated Annealing**: Further optimize any design using simulated annealing with jitter or coordinate swap
+- **Coordinate Swap Annealing**: Specialized annealing that swaps coordinates between points for faster convergence
 - **Python Bindings**: Use the library directly from Python via PyO3 bindings
 
 ## Installation
@@ -100,6 +101,7 @@ The Maximin criterion maximizes the minimum distance between any two points in t
 - The Rust implementation usually finds a better metric than Python alternatives (e.g., 5.95 instead of 7.51)
 - ~84x faster than Python on Macbook Air M2 for 5 samples in 2D across 10,000 iterations
 - ~1440x faster for 50 samples in 3D
+- **2x faster** than Python for design generation with combined coordinate swap + jitter annealing optimization
 
 ### Maximin
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -195,7 +195,7 @@ print(f"Maximin value: {value}")  # Higher is better
 
 ### anneal_lhd
 
-Anneals a Latin Hypercube Design to optimize its metric value using simulated annealing.
+Anneals a Latin Hypercube Design to optimize its metric value using simulated annealing. Supports two strategies: coordinate swap (faster convergence, maintains LHD structure better) or jitter (fine-grained exploration).
 
 ```python
 maxpro.anneal_lhd(
@@ -205,6 +205,7 @@ maxpro.anneal_lhd(
     cooling_rate: float,
     metric_name: str,
     minimize: bool,
+    swap: bool,
     seed: int | None = None
 ) -> list[list[float]]
 ```
@@ -219,6 +220,7 @@ maxpro.anneal_lhd(
 | `cooling_rate` | `float` | Cooling rate for annealing (multiplied by temperature each iteration) |
 | `metric_name` | `str` | Metric name; options are `"maxpro"` and `"maximin"` |
 | `minimize` | `bool` | Whether to minimize the metric (True for MaxPro, False for Maximin) |
+| `swap` | `bool` | Use coordinate swap annealing (True) or jitter annealing (False) |
 | `seed` | `int`, optional | Seed for the random number generator |
 
 **Returns:**
@@ -245,7 +247,7 @@ lhd = maxpro.build_lhd(
     seed=42
 )
 
-# Then optimize with annealing
+# Coordinate swap annealing (faster convergence)
 optimized = maxpro.anneal_lhd(
     design=lhd,
     n_iterations=5000,
@@ -253,15 +255,64 @@ optimized = maxpro.anneal_lhd(
     cooling_rate=0.99,
     metric_name="maxpro",
     minimize=True,
+    swap=True,
+    seed=42
+)
+
+# Jitter annealing (fine-grained exploration)
+optimized = maxpro.anneal_lhd(
+    design=lhd,
+    n_iterations=5000,
+    initial_temp=1.0,
+    cooling_rate=0.99,
+    metric_name="maxpro",
+    minimize=True,
+    swap=False,
     seed=42
 )
 ```
 
 **Annealing Tips:**
 
+- Use `swap=True` for faster convergence while preserving LHD structure
+- Use `swap=False` (jitter) for fine-grained exploration but may break LHD properties
 - `initial_temp`: Higher values allow more exploration but may take longer to converge
 - `cooling_rate`: Closer to 1.0 means slower cooling (more refinement)
 - `n_iterations`: More iterations = more refinement but slower
+
+**Recommended Strategy**
+
+A good rule of thumb is to use **20% of iterations for coordinate swap annealing** and **80% for jitter annealing**. **Coordinate swap annealing should always be performed before jitter annealing** - swap first to quickly converge toward a good solution, then use jitter for fine-grained refinement.
+
+For example, with 50,000 total annealing iterations:
+
+```python
+# 20% swap (10k iterations) - perform this FIRST
+swap_annealed = maxpro.anneal_lhd(
+    design=lhd,
+    n_iterations=10000,
+    initial_temp=1.0,
+    cooling_rate=0.99,
+    metric_name="maxpro",
+    minimize=True,
+    swap=True,
+    seed=42
+)
+
+# 80% jitter (40k iterations) - perform this SECOND
+optimized = maxpro.anneal_lhd(
+    design=swap_annealed,
+    n_iterations=40000,
+    initial_temp=1.0,
+    cooling_rate=0.99,
+    metric_name="maxpro",
+    minimize=True,
+    swap=False,
+    seed=43
+)
+```
+
+**Important**: It is only possible to achieve state-of-the-art performance using at least some coordinate swap annealing steps. Using jitter annealing alone (without coordinate swap) will not achieve competitive results.
 
 <script id="MathJax-script" async src="https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -195,7 +195,7 @@ pub fn maximin_criterion(design: &Vec<Vec<f64>>) -> f64
 
 ### anneal_lhd
 
-Simulated annealing for improving (maximizing or minimizing) a given metric.
+Simulated annealing for improving (maximizing or minimizing) a given metric. Supports two annealing strategies: coordinate swap (faster convergence) or jitter (fine-grained exploration).
 
 ```rust
 pub fn anneal_lhd<F>(
@@ -205,7 +205,8 @@ pub fn anneal_lhd<F>(
     cooling_rate: f64,
     metric: F,
     minimize: bool,
-    seed: u64
+    seed: u64,
+    swap: bool
 ) -> Vec<Vec<f64>>
 where
     F: Fn(&Vec<Vec<f64>>) -> f64,
@@ -222,6 +223,7 @@ where
 | `metric` | `F` | A callable function that maps `&Vec<Vec<f64>>` to `f64` |
 | `minimize` | `bool` | Whether to minimize or maximize the metric |
 | `seed` | `u64` | Random seed |
+| `swap` | `bool` | Use coordinate swap annealing (true) or jitter annealing (false) |
 
 **Returns:**
 
@@ -233,6 +235,7 @@ where
 use maxpro::anneal::anneal_lhd;
 use maxpro::maxpro_utils::maxpro_criterion;
 
+// Coordinate swap annealing (faster convergence)
 let optimized = anneal_lhd(
     &lhd,
     5000,      // n_iterations
@@ -240,9 +243,35 @@ let optimized = anneal_lhd(
     0.99,      // cooling_rate
     maxpro_criterion,
     true,      // minimize
-    42         // seed
+    42,        // seed
+    true       // use coordinate swap
+);
+
+// Jitter annealing (fine-grained exploration)
+let optimized = anneal_lhd(
+    &lhd,
+    5000,
+    1.0,
+    0.99,
+    maxpro_criterion,
+    true,
+    42,
+    false      // use jitter
 );
 ```
+
+**Recommended Strategy**
+
+A good rule of thumb is to use **20% of iterations for coordinate swap annealing** and **80% for jitter annealing**. **Coordinate swap annealing should always be performed before jitter annealing** - swap first to quickly converge toward a good solution, then use jitter for fine-grained refinement.
+
+For example, with 100,000 total annealing iterations:
+
+```rust
+let swap_annealed = anneal_lhd(&lhd, 20000, 1.0, 0.99, metric_fn, true, seed, true);
+let final_annealed = anneal_lhd(&swap_annealed, 80000, 1.0, 0.99, metric_fn, true, seed + 1, false);
+```
+
+**Important**: It is only possible to achieve state-of-the-art performance using at least some coordinate swap annealing steps. Using jitter annealing alone (without coordinate swap) will not achieve competitive results.
 
 ---
 
@@ -262,6 +291,12 @@ cargo run --release -- [OPTIONS]
 | `--samples <SAMPLES>` | Number of samples in the design |
 | `--ndims <NDIMS>` | Number of dimensions |
 | `--metric <METRIC>` | Metric to use: `max-pro` or `maxi-min` |
+| `--seed <SEED>` | Random seed for reproducibility |
+| `--anneal-iterations <ANNEAL_ITERATIONS>` | Number of annealing iterations (default: 100000) |
+| `--anneal-t <ANNEAL_T>` | Initial temperature for annealing (default: 1.0) |
+| `--anneal-cooling <ANNEAL_COOLING>` | Cooling rate for annealing (default: 0.99) |
+| `--output-path <OUTPUT_PATH>` | Path to save output design |
+| `--plot` | Enable plotting (requires debug feature) |
 
 ### Examples
 

--- a/python/comparison_r.py
+++ b/python/comparison_r.py
@@ -135,8 +135,8 @@ def main():
     # Compare runtimes
     SEED = 42
     start_time = time.time()
-    # Use half the R iterations on searching for an LHD, half on annealing.
-    n_iterations = R_ITERATIONS / 2
+    # Split the R iterations between generation and annealing
+    n_iterations = int(R_ITERATIONS / 3)
     maxpro_lhd = maxpro.build_lhd(100, 2, n_iterations, "maxpro", SEED)
 
     initial_temperature = 1.0
@@ -148,6 +148,17 @@ def main():
         cooling_rate,
         "maxpro",
         True,
+        True,
+        SEED,
+    )
+    optimal_maxpro_lhd = maxpro.anneal_lhd(
+        optimal_maxpro_lhd,
+        n_iterations,
+        initial_temperature,
+        cooling_rate,
+        "maxpro",
+        True,
+        False,
         SEED,
     )
     end_time = time.time()

--- a/python/comparisons.py
+++ b/python/comparisons.py
@@ -44,7 +44,8 @@ def benchmark_time_maxpro():
 
     time_rust_start = time.time()
     maxpro_lhd = maxpro.build_lhd(n_samples, n_dim, n_iterations, "maxpro", SEED)
-    maxpro_lhd = maxpro.anneal_lhd(maxpro_lhd, 1000, 1.0, 0.99, "maxpro", True, SEED)
+    # Don't benchmark with swap annealing since it isn't implemented in the comparison
+    maxpro_lhd = maxpro.anneal_lhd(maxpro_lhd, 1000, 1.0, 0.99, "maxpro", True, False, SEED)
     maxpro_criterion = maxpro.maxpro_criterion(maxpro_lhd)
     time_rust_end = time.time()
 
@@ -68,7 +69,7 @@ def benchmark_time_maximin():
     time_rust_start = time.time()
     maximin_lhd = maxpro.build_lhd(n_samples, n_dim, n_iterations, "maximin", SEED)
     maximin_lhd = maxpro.anneal_lhd(
-        maximin_lhd, 1000, 1.0, 0.99, "maximin", False, SEED
+        maximin_lhd, 1000, 1.0, 0.99, "maximin", False, False, SEED
     )
     time_rust_end = time.time()
 

--- a/src/anneal.rs
+++ b/src/anneal.rs
@@ -100,10 +100,10 @@ where
     let mut global_best_metric = best_metric;
 
     for _it in 0..n_iterations {
-        let mut annealed_design = design.clone();
+        let mut annealed_design = global_best_design.clone();
         if swap {
             // Swap rows
-            annealed_design = swap_rows(design, &mut rng);
+            annealed_design = swap_rows(&annealed_design, &mut rng);
         } else {
             for row in annealed_design.iter_mut() {
                 for elem in row.iter_mut() {

--- a/src/anneal.rs
+++ b/src/anneal.rs
@@ -55,6 +55,7 @@ pub fn swap_rows(lhd: &Vec<Vec<f64>>, rng: &mut StdRng) -> Vec<Vec<f64>> {
 ///     cooling rate (f64): Cooling rate, used to simulate annealing by reducing the metropolis algorithm acceptance
 ///     metric (F): A callable function that maps &Vec<Vec<f64>> to f64, used to minimize or maximize
 ///     minimize (bool): Whether to minimize or maximize the metric
+///     swap (bool): Whether to use swapping or random jitter to find a more optimal design
 ///
 /// Returns:
 ///     Vec<Vec<f64>>: A metric-optimized collection of points, not necessarily a latin hypercube.
@@ -66,6 +67,7 @@ pub fn anneal_lhd<F>(
     metric: F,
     minimize: bool,
     seed: u64,
+    swap: bool,
 ) -> Vec<Vec<f64>>
 where
     F: Fn(&Vec<Vec<f64>>) -> f64,
@@ -85,6 +87,11 @@ where
     let mut temp = initial_temp;
     let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
 
+    // Set max step size as +/- 1% of the size of the design interval
+    // for jitter annealing
+    let n_samples: usize = design.len();
+    let step_size: f64 = 0.01 / n_samples as f64;
+
     let mut best_design = design.clone();
     let mut best_metric = metric(design);
 
@@ -93,8 +100,18 @@ where
     let mut global_best_metric = best_metric;
 
     for _it in 0..n_iterations {
-        // Swap rows
-        let annealed_design = swap_rows(design, &mut rng);
+        let mut annealed_design = design.clone();
+        if swap {
+            // Swap rows
+            annealed_design = swap_rows(design, &mut rng);
+        } else {
+            for row in annealed_design.iter_mut() {
+                for elem in row.iter_mut() {
+                    // Dereference to update elem in place
+                    *elem = (*elem + rng.random_range(-step_size..step_size)).clamp(0.0, 1.0)
+                }
+            }
+        }
         // Calculate new metric
         let new_metric = metric(&annealed_design);
         let mut metric_diff = new_metric - best_metric;

--- a/src/anneal.rs
+++ b/src/anneal.rs
@@ -159,6 +159,7 @@ where
 ///     cooling_rate (float): Cooling rate for annealing
 ///     metric_name (str): metric name; options are "maxpro" and "maximin"
 ///     minimize (bool): Whether to minimize the metric
+///     swap (bool): Whether to use coordinate swap annealing
 ///     seed (int, optional): Seed for the random number generator.
 ///
 /// Returns:
@@ -171,6 +172,7 @@ pub fn py_anneal_lhd(
     cooling_rate: f64,
     metric_name: String,
     minimize: bool,
+    swap: bool,
     seed: Option<u64>,
 ) -> PyResult<Vec<Vec<f64>>> {
     if n_iterations == 0 {
@@ -203,5 +205,6 @@ pub fn py_anneal_lhd(
         metric,
         minimize,
         rng_seed,
+        swap,
     ))
 }

--- a/src/anneal.rs
+++ b/src/anneal.rs
@@ -12,6 +12,42 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
+const N_SWAP_ITERATIONS: usize = 10;
+
+pub fn swap_rows(lhd: &Vec<Vec<f64>>, rng: &mut StdRng) -> Vec<Vec<f64>> {
+    // First clone the original LHD
+    let mut lhd_swapped = lhd.clone();
+
+    // Identify row and columns to switch
+    // Start by defining muts in outer scope
+    let mut swap_idx_1_row = 0;
+    let mut swap_idx_1_col = 0;
+    let mut swap_idx_2_row = 0;
+    let mut swap_idx_2_col = 0;
+
+    for _ in 0..N_SWAP_ITERATIONS {
+        // Iterate to find different values
+        swap_idx_1_row = rng.random_range(0..lhd.len());
+        swap_idx_1_col = rng.random_range(0..lhd[0].len());
+        swap_idx_2_row = rng.random_range(0..lhd.len());
+        swap_idx_2_col = rng.random_range(0..lhd[0].len());
+        if (swap_idx_1_row, swap_idx_1_col) != (swap_idx_2_row, swap_idx_2_col) {
+            // Break once different values are found
+            break;
+        }
+    }
+
+    // Get swap values
+    let swap_value_1 = lhd[swap_idx_1_row][swap_idx_1_col];
+    let swap_value_2 = lhd[swap_idx_2_row][swap_idx_2_col];
+
+    // Swap values
+    lhd_swapped[swap_idx_1_row][swap_idx_1_col] = swap_value_2;
+    lhd_swapped[swap_idx_2_row][swap_idx_2_col] = swap_value_1;
+
+    lhd_swapped
+}
+
 /// Simulated annealing for improving (maximizing or minimizing) a given metric.
 ///
 /// Arguments:
@@ -61,15 +97,16 @@ where
     let mut global_best_metric = best_metric;
 
     for _it in 0..n_iterations {
-        // Modify the design
-        let mut annealed_design = best_design.clone();
+        let annealed_design = swap_rows(design, &mut rng);
+        // // Modify the design
+        // let mut annealed_design = best_design.clone();
 
-        for row in annealed_design.iter_mut() {
-            for elem in row.iter_mut() {
-                // Dereference to update elem in place
-                *elem = (*elem + rng.random_range(-step_size..step_size)).clamp(0.0, 1.0)
-            }
-        }
+        // for row in annealed_design.iter_mut() {
+        //     for elem in row.iter_mut() {
+        //         // Dereference to update elem in place
+        //         *elem = (*elem + rng.random_range(-step_size..step_size)).clamp(0.0, 1.0)
+        //     }
+        // }
 
         // Calculate new metric
         let new_metric = metric(&annealed_design);

--- a/src/anneal.rs
+++ b/src/anneal.rs
@@ -100,7 +100,7 @@ where
     let mut global_best_metric = best_metric;
 
     for _it in 0..n_iterations {
-        let mut annealed_design = global_best_design.clone();
+        let mut annealed_design = best_design.clone();
         if swap {
             // Swap rows
             annealed_design = swap_rows(&annealed_design, &mut rng);

--- a/src/anneal.rs
+++ b/src/anneal.rs
@@ -12,8 +12,6 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
-const N_SWAP_ITERATIONS: usize = 10;
-
 /// Perform a coordinate swap of two rows in a column
 ///
 /// Arguments:
@@ -22,36 +20,23 @@ const N_SWAP_ITERATIONS: usize = 10;
 ///
 /// Returns:
 ///     Vec<Vec<f64>>: lhd with a coordinate swap
-fn swap_rows(lhd: &Vec<Vec<f64>>, rng: &mut StdRng) -> Vec<Vec<f64>> {
-    // First clone the original LHD
-    let mut lhd_swapped = lhd.clone();
-
+fn swap_rows(lhd: &mut Vec<Vec<f64>>, rng: &mut StdRng) -> () {
     // Identify row and columns to switch
-    // Start by defining muts in outer scope
-    let mut swap_idx_1_row = 0;
-    let mut swap_idx_2_row = 0;
-    let mut swap_idx_col = 0;
+    let n_rows = lhd.len();
+    let n_cols = lhd[0].len();
 
-    for _ in 0..N_SWAP_ITERATIONS {
-        // Iterate to find different values
-        swap_idx_1_row = rng.random_range(0..lhd.len());
-        swap_idx_2_row = rng.random_range(0..lhd.len());
-        swap_idx_col = rng.random_range(0..lhd[0].len());
-        if (swap_idx_1_row, swap_idx_col) != (swap_idx_2_row, swap_idx_col) {
-            // Break once different values are found
-            break;
-        }
-    }
+    // Iterate to find different values
+    let swap_idx_1_row = rng.random_range(0..n_rows);
+    let swap_idx_2_row = rng.random_range(0..n_rows);
+    let swap_idx_col = rng.random_range(0..n_cols);
 
     // Get swap values
     let swap_value_1 = lhd[swap_idx_1_row][swap_idx_col];
     let swap_value_2 = lhd[swap_idx_2_row][swap_idx_col];
 
     // Swap values
-    lhd_swapped[swap_idx_1_row][swap_idx_col] = swap_value_2;
-    lhd_swapped[swap_idx_2_row][swap_idx_col] = swap_value_1;
-
-    lhd_swapped
+    lhd[swap_idx_1_row][swap_idx_col] = swap_value_2;
+    lhd[swap_idx_2_row][swap_idx_col] = swap_value_1;
 }
 
 /// Simulated annealing for improving (maximizing or minimizing) a given metric.
@@ -111,7 +96,7 @@ where
         let mut annealed_design = best_design.clone();
         if swap {
             // Swap rows
-            annealed_design = swap_rows(&annealed_design, &mut rng);
+            swap_rows(&mut annealed_design, &mut rng);
         } else {
             for row in annealed_design.iter_mut() {
                 for elem in row.iter_mut() {

--- a/src/anneal.rs
+++ b/src/anneal.rs
@@ -21,29 +21,27 @@ pub fn swap_rows(lhd: &Vec<Vec<f64>>, rng: &mut StdRng) -> Vec<Vec<f64>> {
     // Identify row and columns to switch
     // Start by defining muts in outer scope
     let mut swap_idx_1_row = 0;
-    let mut swap_idx_1_col = 0;
     let mut swap_idx_2_row = 0;
-    let mut swap_idx_2_col = 0;
+    let mut swap_idx_col = 0;
 
     for _ in 0..N_SWAP_ITERATIONS {
         // Iterate to find different values
         swap_idx_1_row = rng.random_range(0..lhd.len());
-        swap_idx_1_col = rng.random_range(0..lhd[0].len());
         swap_idx_2_row = rng.random_range(0..lhd.len());
-        swap_idx_2_col = rng.random_range(0..lhd[0].len());
-        if (swap_idx_1_row, swap_idx_1_col) != (swap_idx_2_row, swap_idx_2_col) {
+        swap_idx_col = rng.random_range(0..lhd[0].len());
+        if (swap_idx_1_row, swap_idx_col) != (swap_idx_2_row, swap_idx_col) {
             // Break once different values are found
             break;
         }
     }
 
     // Get swap values
-    let swap_value_1 = lhd[swap_idx_1_row][swap_idx_1_col];
-    let swap_value_2 = lhd[swap_idx_2_row][swap_idx_2_col];
+    let swap_value_1 = lhd[swap_idx_1_row][swap_idx_col];
+    let swap_value_2 = lhd[swap_idx_2_row][swap_idx_col];
 
     // Swap values
-    lhd_swapped[swap_idx_1_row][swap_idx_1_col] = swap_value_2;
-    lhd_swapped[swap_idx_2_row][swap_idx_2_col] = swap_value_1;
+    lhd_swapped[swap_idx_1_row][swap_idx_col] = swap_value_2;
+    lhd_swapped[swap_idx_2_row][swap_idx_col] = swap_value_1;
 
     lhd_swapped
 }
@@ -83,9 +81,7 @@ where
         initial_temp > 0.0,
         "initial_temp must be positive and nonzero"
     );
-    // Set max step size as +/- 1% of the size of the design interval
-    let n_samples: usize = design.len();
-    let step_size: f64 = 0.01 / n_samples as f64;
+
     let mut temp = initial_temp;
     let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
 
@@ -97,17 +93,8 @@ where
     let mut global_best_metric = best_metric;
 
     for _it in 0..n_iterations {
+        // Swap rows
         let annealed_design = swap_rows(design, &mut rng);
-        // // Modify the design
-        // let mut annealed_design = best_design.clone();
-
-        // for row in annealed_design.iter_mut() {
-        //     for elem in row.iter_mut() {
-        //         // Dereference to update elem in place
-        //         *elem = (*elem + rng.random_range(-step_size..step_size)).clamp(0.0, 1.0)
-        //     }
-        // }
-
         // Calculate new metric
         let new_metric = metric(&annealed_design);
         let mut metric_diff = new_metric - best_metric;

--- a/src/anneal.rs
+++ b/src/anneal.rs
@@ -14,7 +14,7 @@ use rand::rngs::StdRng;
 
 const N_SWAP_ITERATIONS: usize = 10;
 
-pub fn swap_rows(lhd: &Vec<Vec<f64>>, rng: &mut StdRng) -> Vec<Vec<f64>> {
+fn swap_rows(lhd: &Vec<Vec<f64>>, rng: &mut StdRng) -> Vec<Vec<f64>> {
     // First clone the original LHD
     let mut lhd_swapped = lhd.clone();
 

--- a/src/anneal.rs
+++ b/src/anneal.rs
@@ -14,6 +14,14 @@ use rand::rngs::StdRng;
 
 const N_SWAP_ITERATIONS: usize = 10;
 
+/// Perform a coordinate swap of two rows in a column
+///
+/// Arguments:
+///     lhd (&Vec<Vec<f64>>): Initial design
+///     rng (&mut StdRung): RNG for generating random indices
+///
+/// Returns:
+///     Vec<Vec<f64>>: lhd with a coordinate swap
 fn swap_rows(lhd: &Vec<Vec<f64>>, rng: &mut StdRng) -> Vec<Vec<f64>> {
     // First clone the original LHD
     let mut lhd_swapped = lhd.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn main() {
     // Optimize the metric, first by swapping
     let swap_annealed_design = anneal_lhd(
         &lhd,
-        annealing_iterations / 10,
+        annealing_iterations / 5,
         annealing_t,
         annealing_cooling,
         metric_fn,
@@ -86,7 +86,7 @@ fn main() {
     // Optimize the metric, then by jitter
     let annealed_design = anneal_lhd(
         &swap_annealed_design,
-        annealing_iterations - (annealing_iterations / 10),
+        annealing_iterations - (annealing_iterations / 5),
         annealing_t,
         annealing_cooling,
         metric_fn,

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,21 +71,35 @@ fn main() {
     let lhd: Vec<Vec<f64>> = build_lhd(n_samples, n_dims, n_iterations, Some(metric), seed);
 
     let metric_value = metric_fn(&lhd);
-    // Optimize the metric
-    let annealed_design = anneal_lhd(
+    // Optimize the metric, first by swapping
+    let swap_annealed_design = anneal_lhd(
         &lhd,
-        annealing_iterations,
+        annealing_iterations / 10,
         annealing_t,
         annealing_cooling,
         metric_fn,
         minimize,
         seed + 1,
+        true,
+    );
+    let swap_annealed_metric = metric_fn(&swap_annealed_design);
+    // Optimize the metric, then by jitter
+    let annealed_design = anneal_lhd(
+        &swap_annealed_design,
+        annealing_iterations - (annealing_iterations / 10),
+        annealing_t,
+        annealing_cooling,
+        metric_fn,
+        minimize,
+        seed + 2,
+        false,
     );
     let annealed_metric = metric_fn(&annealed_design);
 
     // Outputs
     println!("{:?}", annealed_design);
     println!("Original metric: {metric_value}");
+    println!("Swapped metric: {swap_annealed_metric}");
     println!("Annealed metric: {annealed_metric}");
 
     // Plot, if requested

--- a/src/maxpro_utils.rs
+++ b/src/maxpro_utils.rs
@@ -7,6 +7,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
+use rayon::prelude::*;
 
 /// Helper function to calculate the internal sum term of the MaxPro criterion (psi(D)).
 /// This sum is the term that is directly minimized in the optimization
@@ -28,31 +29,30 @@ fn maxpro_sum(design: &Vec<Vec<f64>>) -> f64 {
         return 0.0;
     }
 
-    let mut inverse_product_sum: f64 = 0.0;
     let epsilon: f64 = 1e-12; // Small constant to prevent division by zero
 
-    for i in 0..n {
-        for j in (i + 1)..n {
-            // Calculate the product term: product_{l=1}^{d} (x_il - x_jl)^2
+    // Calculate the product term: product_{l=1}^{d} (x_il - x_jl)^2
+    let inverse_product_sum: f64 = (0..n)
+        .into_par_iter()
+        .map(|i| {
             let row_i: &Vec<f64> = &design[i];
-            let row_j: &Vec<f64> = &design[j];
-            let mut product_of_squared_diffs: f64 = 1.0;
-
-            // Use zip to iterate over both rows simultaneously
-            for (x_i_l, x_j_l) in row_i.iter().zip(row_j.iter()) {
-                let diff: f64 = x_i_l - x_j_l;
-                let diff_sq: f64 = diff * diff;
-                product_of_squared_diffs *= diff_sq;
+            let mut inverse_product: f64 = 0.0;
+            for j in (i + 1)..n {
+                let row_j: &Vec<f64> = &design[j];
+                let mut product_of_squared_diffs: f64 = 1.0;
+                // Use zip to iterate over both rows simultaneously
+                for (x_i_l, x_j_l) in row_i.iter().zip(row_j.iter()) {
+                    let diff: f64 = x_i_l - x_j_l;
+                    let diff_sq: f64 = diff * diff;
+                    product_of_squared_diffs *= diff_sq;
+                }
+                // Add epsilon to prevent division by zero
+                product_of_squared_diffs += epsilon;
+                inverse_product += 1.0 / product_of_squared_diffs;
             }
-
-            // Add epsilon to prevent division by zero
-            product_of_squared_diffs += epsilon;
-
-            // // Sum the inverse products
-            inverse_product_sum += 1.0 / product_of_squared_diffs;
-        }
-    }
-
+            inverse_product
+        })
+        .sum();
     inverse_product_sum
 }
 


### PR DESCRIPTION
**Description:**
Use coordinate swaps to "anneal" the LHD to a better state. 

This marks a meaningful improvement in basic testing by first swapping to find a more global optimum before jittering to get the final result. 

Before:
```
Original metric: 47.212392080262525
Annealed metric: 34.35702034394655
```

After:
```
Original metric: 47.212392080262525
Swapped metric: 33.16778846090125
Annealed metric: 26.71736436397349
```

This implementation now gets comparable-or-better metric values to the R implementation, but is 4x slower.

Current status: Investigating optimizations.
* Most of the runtime of annealing is spent calculating the maxpro metric, profiled using samply:
<img width="520" height="181" alt="image" src="https://github.com/user-attachments/assets/e2283e04-ec95-4687-967a-1aafbe9aca41" />

```
cargo build --profile profiling
samply record ./target/profiling/maxpro --samples 200 --ndims 20 --iterations 500 --metric max-pro --seed 12345
```

* Obvious first improvement is to use rayon to parallelize the maxpro sum, expect a ~2x improvement in performance
* Parallelizing the maxpro metric calculation only gets us so far (within 2x). Looks like the real trick in R is only recalculating the specific part of the sums that change, which is a tricky indexing job if nothing else. Because this is a major improvement as-is, it may be worth shipping this slower version and tracking performance improvements separately.

To Do:
* (Potential follow-up) change API so the user doesn't have to separately run an annealing step, they just specify how many steps and it generates a sequence.

**Testing:**
Comparisons, R comparisons run. 
Main runs. 
Tests pass.

Benchmark slows due to use of slower coordinate swap annealing instead of just jitter.

**Impacts:**
- [x] Rust
- [x] Python
