### PR TITLE
Ordered designs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 .ruff_cache/
 .venv/
+.DS_Store
 *.lock
 *.png
 target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maxpro"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 repository = "https://github.com/mrhheffernan/maxpro"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Versions 0.1.* are reserved for bug fixes and performance improvements to existi
 ## AI Policy
 This project's AI policy is that no AI-written code is included in the core Rust module or in the python bindings. AI-written code may be present in the `python/` directory but is restricted to analysis. AI code is not used for benchmarking either correctness or speed. 
 
-Gemini code review is used in development and any code suggestions must be human tested. No AI-generated or vibe-coded contributions will be accepted.
+Gemini code review is used in development and any code suggestions must be human tested and are not auto-accepted. No AI-generated contributions will be accepted, neither will code contributions where the author cannot explain design choices and tradeoffs.
 
 ## Style
 Rust formatting by `cargo fmt`. Python formatting by `ruff`. `flake8` used for PEP, line length not enforced in docstrings within reason.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Rust criterion 0.22187155920586812 in 0.02611827850341797 s
 Python criterion 0.23394896276844854 in 0.07612800598144531 s
 Python/Rust ratio: 2.914740570343594
 Benchmark ordering designs
-Mean time to order design: 0.017710449695587157 s
+Mean time to order design: 5.19455441236496 s
 ```
 
 The MaxPro metric calculation can be differentially tested against the R package as the source of truth. 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Rust criterion 0.22187155920586812 in 0.02611827850341797 s
 Python criterion 0.23394896276844854 in 0.07612800598144531 s
 Python/Rust ratio: 2.914740570343594
 Benchmark ordering designs
-Mean time to order design: 0.01796654224395752 s
+Mean time to order design: 0.017854173183441163 s
 ```
 
 The MaxPro metric calculation can be differentially tested against the R package as the source of truth. 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Rust criterion 0.22187155920586812 in 0.02611827850341797 s
 Python criterion 0.23394896276844854 in 0.07612800598144531 s
 Python/Rust ratio: 2.914740570343594
 Benchmark ordering designs
-Mean time to order design: 5.19455441236496 s
+Mean time to order design: 5.129399230480194 s
 ```
 
 The MaxPro metric calculation can be differentially tested against the R package as the source of truth. 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Rust criterion 0.22187155920586812 in 0.02611827850341797 s
 Python criterion 0.23394896276844854 in 0.07612800598144531 s
 Python/Rust ratio: 2.914740570343594
 Benchmark ordering designs
-Mean time to order design: 0.017854173183441163 s
+Mean time to order design: 0.017710449695587157 s
 ```
 
 The MaxPro metric calculation can be differentially tested against the R package as the source of truth. 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Rust build](https://github.com/mrhheffernan/maxpro/actions/workflows/rust-build-test.yml/badge.svg)](https://github.com/mrhheffernan/maxpro/actions/workflows/rust-build-test.yml)
 [![Documentation](https://img.shields.io/badge/docs-mrhheffernan.github.io/maxpro-blue)](https://mrhheffernan.github.io/maxpro/)
 
-**[Documentation](https://mrhheffernan.github.io/maxpro/)**
-
 This is a minimal Rust implementation of Latin Hypercube Design (LHD) generation with the Maximum Projection metric. 
 It pursues an initial random search for a relatively-optimal candidate and allows for further 
 optimization of that candidate (or any other supplied) in search of a better solution, although
@@ -28,35 +26,27 @@ The Maximin metric is included for additional functionality and performance benc
 - Generate many random latin hypercubes, calculate the maximin metric, and return the LHD that maximizes the minimum distance between points: `cargo run --release -- --iterations 100000 --samples 50 --ndims 2 --metric maxi-min`
 - Using `maturin develop --release --features pyo3-bindings`, can `import maxpro` and generate optimal MaxPro LHDs in Python directly.
 - Perturb a LHD to optimize its metric
+- Switch coordinates in a LHD to optimize its metric
+- Order the points in an LHD so that the first n points have as-optimal a space coverage as possible. This allows for higher-quality interim analyses.
 
 ## Usage
+For complete usage information and examples, see the **[Documentation](https://mrhheffernan.github.io/maxpro/)**. 
 
 ### Rust
 Add the crate to your project via Cargo (`cargo add maxpro`), then `using maxpro::<>` you can use any of the underlying components.
 
 ### Python
 Install with `pip install maxpro`, `uv add maxpro`, or your other favorite package management tool.
-
-In version 0.1.0, you must import as
-```
-import _maxpro as maxpro
-```
-in 0.1.1, this is replaced with
 ```
 import maxpro
 ```
 
 ## Planned work 
 
-Versions 0.1.* are reserved for bug fixes and performance improvements to existing functionality, new features will land in 0.2.0.
-
-### 0.1.1
-- Resolve python import syntax
-- Make output path optional
-- Seedable RNGs (pulled in from 0.2.0)
+Versions 0.1.* are reserved for bug fixes and performance improvements to existing functionality, and bringing features for continuous variable design construction to parity with the R implemented. 0.2.0 is the planned full-feature-parity release.
 
 ### 0.2.0
-- Ordering the designs for optimal execution order
+- Categorical design dimensions
 
 ## AI Policy
 This project's AI policy is that no AI-written code is included in the core Rust module or in the python bindings. AI-written code may be present in the `python/` directory but is restricted to analysis. AI code is not used for benchmarking either correctness or speed. 
@@ -74,17 +64,18 @@ MaxPro design and optimization: The Rust implementation usually finds a better m
 
 Maximin design and optimization is benchmarked against PyDOE3 as the reference implementation. The Rust and Python implementations return almost identical results (0.22 in this implementation vs 0.21 in PyDOE3) with this implementation offering a 2.63x speedup for 5 samples in 2D across 10,000 iterations. Increasing this to 50 samples in 3D, this implementation returns a better result than PyDOE3 (0.2204 vs 0.2072) with a 2.9x speedup (0.0286s vs. 0.083s).
 
-
 Benchmarks are run with `python/comparisons.py`.
 Last PR's benchmarks, with `maturin develop --features pyo3-bindings --release` to build locally:
 ```
-Rust calculation: 72.39111811323956 in 0.0381779670715332 s
-Python calculation: 93.14236082134553 in 25.153131008148193 s
-Python / Rust ratio: 658.8389308686692
+Rust calculation: 72.39111811323956 in 0.039016008377075195 s
+Python calculation: 89.28355821451629 in 25.08482003211975 s
+Python / Rust ratio: 642.9366066790919
 Benchmarking Maximin time against reference implementation
-Rust criterion 0.22187155920586812 in 0.026096105575561523 s
-Python criterion 0.22642738855220698 in 0.0776219367980957 s
-Python/Rust ratio: 2.9744643917591707
+Rust criterion 0.22187155920586812 in 0.02611827850341797 s
+Python criterion 0.23394896276844854 in 0.07612800598144531 s
+Python/Rust ratio: 2.914740570343594
+Benchmark ordering designs
+Mean time to order design: 0.01796654224395752 s
 ```
 
 The MaxPro metric calculation can be differentially tested against the R package as the source of truth. 
@@ -97,7 +88,6 @@ Benchmarks below can be reproduced [here](https://colab.research.google.com/driv
 ```
 R calculation: 95.98506 
 Rust calculation: 95.98505099515626
-Design with metric 94.60228692529198 found in 1.3302018642425537 seconds
-Rust/R runtime ratio: 0.24169013961983982
+Design with metric 94.60228692529198 found in 1.342952013015747 seconds
+Rust/R runtime ratio: 0.24400676938860166
 ```
-

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -314,6 +314,68 @@ optimized = maxpro.anneal_lhd(
 
 **Important**: It is only possible to achieve state-of-the-art performance using at least some coordinate swap annealing steps. Using jitter annealing alone (without coordinate swap) will not achieve competitive results.
 
+---
+
+### order_design
+
+Reorders a design to optimize the run order for sequential experimentation. The algorithm selects a center point (closest to the design center), then greedily adds remaining points that optimize the chosen criterion at each step. This produces designs where early subsets are already well-distributed, making it ideal for surrogate modeling workflows where you want preliminary results from initial runs.
+
+```python
+maxpro.order_design(design: list[list[float]], metric_name: str) -> list[list[float]]
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `design` | `list[list[float]]` | Design to reorder. Must not be empty. |
+| `metric_name` | `str` | Criterion to use: `'maxpro'` or `'maximin'` |
+
+**Returns:**
+
+`list[list[float]]` - The design with elements reordered for optimal run order
+
+**Raises:**
+
+- `ValueError` if design is empty
+- `ValueError` if `metric_name` is not `'maxpro'` or `'maximin'`
+
+**Algorithm:**
+
+1. **Center Selection**: Find the point closest to the design center (0.5, 0.5, ...) and place it first
+2. **Greedy Selection**: For remaining points, evaluate each candidate by appending it to the current ordered design and computing the criterion value. Select the point that produces the best value.
+3. **Repeat** until all points are ordered
+
+**When to Use:**
+
+Use `order_design` when:
+- Running sequential experiments where early subsets should be well-distributed
+- Building surrogate models incrementally and need good coverage from initial runs
+- Comparing designs at multiple stopping points (e.g., 10, 25, 50, 100 samples)
+
+**Example:**
+
+```python
+import maxpro
+
+# Generate a design
+lhd = maxpro.build_lhd(
+    n_samples=100,
+    n_dim=5,
+    n_iterations=500,
+    metric="maxpro",
+    seed=42
+)
+
+# Order for optimal run order
+ordered = maxpro.order_design(lhd, metric_name="maxpro")
+
+# Now you can use subsets like ordered[:10], ordered[:25], etc.
+# and each subset will already be well-distributed
+```
+
+---
+
 <script id="MathJax-script" async src="https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
   window.MathJax = {

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -320,6 +320,8 @@ optimized = maxpro.anneal_lhd(
 
 Reorders a design to optimize the run order for sequential experimentation. The algorithm selects a center point (closest to the design center), then greedily adds remaining points that optimize the chosen criterion at each step. This produces designs where early subsets are already well-distributed, making it ideal for surrogate modeling workflows where you want preliminary results from initial runs.
 
+**Note**: This function is designed for unit hypercubes (designs with coordinates in the [0, 1] range). The center point is assumed to be at (0.5, 0.5, ...).
+
 ```python
 maxpro.order_design(design: list[list[float]], metric_name: str) -> list[list[float]]
 ```

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -278,6 +278,8 @@ let final_annealed = anneal_lhd(&swap_annealed, 80000, 1.0, 0.99, metric_fn, tru
 
 Reorders a design to optimize the run order for sequential experimentation. The algorithm selects a center point (closest to the design center), then greedily adds remaining points that optimize the chosen criterion at each step. This produces designs where early subsets are already well-distributed.
 
+**Note**: This function is designed for unit hypercubes (designs with coordinates in the [0, 1] range). The center point is assumed to be at (0.5, 0.5, ...).
+
 ```rust
 pub fn order_design<F>(lhd: Vec<Vec<f64>>, metric: F, minimize: bool) -> Vec<Vec<f64>>
 where

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -275,6 +275,52 @@ let final_annealed = anneal_lhd(&swap_annealed, 80000, 1.0, 0.99, metric_fn, tru
 
 ---
 
+### order_design
+
+Reorders a design to optimize the run order for sequential experimentation. The algorithm selects a center point (closest to the design center), then greedily adds remaining points that optimize the chosen criterion at each step. This produces designs where early subsets are already well-distributed.
+
+```rust
+pub fn order_design<F>(lhd: Vec<Vec<f64>>, metric: F, minimize: bool) -> Vec<Vec<f64>>
+where
+    F: Fn(&Vec<Vec<f64>>) -> f64,
+```
+
+**Arguments:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `lhd` | `Vec<Vec<f64>>` | Design to reorder |
+| `metric` | `F` | A callable function mapping `&Vec<Vec<f64>>` to `f64` |
+| `minimize` | `bool` | Whether to minimize the metric (true for MaxPro, false for Maximin) |
+
+**Returns:**
+
+`Vec<Vec<f64>>` - The design with elements reordered for optimal run order
+
+**Algorithm:**
+
+1. Find the point closest to the design center (0.5, 0.5, ...) and place it first
+2. For remaining points, greedily select the point that produces the best criterion value when appended
+3. Repeat until all points are ordered
+
+**When to Use:**
+
+- Running sequential experiments where early subsets should be well-distributed
+- Building surrogate models incrementally and need good coverage from initial runs
+- Comparing designs at multiple stopping points (e.g., 10, 25, 50, 100 samples)
+
+**Example:**
+
+```rust
+use maxpro::order::order_design;
+use maxpro::maxpro_utils::maxpro_criterion;
+
+let lhd = maxpro::build_lhd(100, 5, 500, Some(Metrics::MaxPro), 42);
+let ordered = order_design(lhd, maxpro_criterion, true);
+```
+
+---
+
 ## CLI Usage
 
 Build and run:

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -78,7 +78,6 @@ pub fn generate_lhd(
 
 **Panics:**
 
-- If `n_samples == 0`
 - If `n_dim == 0`
 - If `n_samples` or `n_dim` is too large to index
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -312,6 +312,7 @@ where
 **Example:**
 
 ```rust
+use maxpro::enums::Metrics;
 use maxpro::order::order_design;
 use maxpro::maxpro_utils::maxpro_criterion;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "maxpro"
-version = "0.1.1"
+version = "0.1.2"
 description = "Maximum Projection and Maximin Latin Hypercube Design creation and optimization"
 authors = [
     { name = "Matthew Heffernan" }

--- a/python/comparisons.py
+++ b/python/comparisons.py
@@ -45,7 +45,9 @@ def benchmark_time_maxpro():
     time_rust_start = time.time()
     maxpro_lhd = maxpro.build_lhd(n_samples, n_dim, n_iterations, "maxpro", SEED)
     # Don't benchmark with swap annealing since it isn't implemented in the comparison
-    maxpro_lhd = maxpro.anneal_lhd(maxpro_lhd, 1000, 1.0, 0.99, "maxpro", True, False, SEED)
+    maxpro_lhd = maxpro.anneal_lhd(
+        maxpro_lhd, 1000, 1.0, 0.99, "maxpro", True, False, SEED
+    )
     maxpro_criterion = maxpro.maxpro_criterion(maxpro_lhd)
     time_rust_end = time.time()
 

--- a/python/comparisons.py
+++ b/python/comparisons.py
@@ -90,6 +90,21 @@ def benchmark_time_maximin():
     print(f"Python/Rust ratio: {python_timer / rust_timer}")
 
 
+def benchmark_order_designs():
+    n_samples = 50
+    n_iterations = 1000
+    n_dim = 5
+    n_rounds = 100
+
+    maxpro_lhd = maxpro.build_lhd(n_samples, n_dim, n_iterations, "maxpro", SEED)
+
+    time_start = time.time()
+    for _ in range(n_rounds):
+        maxpro.order_design(maxpro_lhd, "maxpro")
+    time_end = time.time()
+    print(f"Mean time to order design: {(time_end - time_start) / n_rounds} s")
+
+
 def main():
     print("Checking parity")
     test_parity()
@@ -99,6 +114,9 @@ def main():
 
     print("Benchmarking Maximin time against reference implementation")
     benchmark_time_maximin()
+
+    print("Benchmark ordering designs")
+    benchmark_order_designs()
 
 
 if __name__ == "__main__":

--- a/python/comparisons.py
+++ b/python/comparisons.py
@@ -91,7 +91,7 @@ def benchmark_time_maximin():
 
 
 def benchmark_order_designs():
-    n_samples = 50
+    n_samples = 500
     n_iterations = 1000
     n_dim = 5
     n_rounds = 100

--- a/src/anneal.rs
+++ b/src/anneal.rs
@@ -20,7 +20,7 @@ use rand::rngs::StdRng;
 ///
 /// Returns:
 ///     Vec<Vec<f64>>: lhd with a coordinate swap
-fn swap_rows(lhd: &mut Vec<Vec<f64>>, rng: &mut StdRng) -> () {
+fn swap_rows(lhd: &mut Vec<Vec<f64>>, rng: &mut StdRng) {
     // Identify row and columns to switch
     let n_rows = lhd.len();
     let n_cols = lhd[0].len();
@@ -48,6 +48,7 @@ fn swap_rows(lhd: &mut Vec<Vec<f64>>, rng: &mut StdRng) -> () {
 ///     cooling rate (f64): Cooling rate, used to simulate annealing by reducing the metropolis algorithm acceptance
 ///     metric (F): A callable function that maps &Vec<Vec<f64>> to f64, used to minimize or maximize
 ///     minimize (bool): Whether to minimize or maximize the metric
+///     seed (u64): Random number seed
 ///     swap (bool): Whether to use swapping or random jitter to find a more optimal design
 ///
 /// Returns:

--- a/src/lhd.rs
+++ b/src/lhd.rs
@@ -7,6 +7,7 @@ use pyo3::exceptions::PyValueError;
 #[cfg(feature = "pyo3-bindings")]
 use pyo3::prelude::*;
 use rand::Rng;
+#[cfg(any(test, feature = "pyo3-bindings"))]
 use rand::SeedableRng;
 use rand::prelude::SliceRandom;
 use rand::rngs::StdRng;

--- a/src/lhd.rs
+++ b/src/lhd.rs
@@ -93,14 +93,12 @@ pub fn plot_x_vs_y(
 ///     Vec<Vec<f64>>: A latin hypercube design
 ///
 /// Panics:
-///     n_samples == 0: n_samples must be positive and nonzero
 ///     n_dim == 0: n_dim must be positive and nonzero
 pub fn generate_lhd(n_samples: u64, n_dim: u64, rng: &mut StdRng) -> Vec<Vec<f64>> {
-    assert!(
-        n_samples > 0,
-        "n_samples must be a positive, nonzero integer"
-    );
-
+    if n_samples == 0 {
+        // No samples requested returns an empty array
+        return Vec::new();
+    }
     assert!(
         n_samples <= usize::MAX as u64,
         "n_samples too large to index"
@@ -157,14 +155,14 @@ fn test_generate_lhd() {
 }
 
 #[test]
-#[should_panic]
-/// Ensure for 0 samples, generate_lhd panics.
+/// Ensure for 0 samples, generate_lhd returns an empty vec.
 fn test_generate_lhd_0_samples() {
     let n_samples: u64 = 0;
     let n_dim: u64 = 4;
     let seed: u64 = 12345;
     let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
-    generate_lhd(n_samples, n_dim, &mut rng);
+    let empty_vec = generate_lhd(n_samples, n_dim, &mut rng);
+    assert!(empty_vec.is_empty());
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,5 +172,6 @@ fn maxpro(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(maximin_utils::py_maximin_criterion, m)?)?;
     m.add_function(wrap_pyfunction!(crate::py_build_lhd, m)?)?;
     m.add_function(wrap_pyfunction!(anneal::py_anneal_lhd, m)?)?;
+    m.add_function(wrap_pyfunction!(order::py_order_design, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ pub mod lhd;
 pub mod maximin_utils;
 pub mod maxpro_utils;
 pub mod order;
-use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod enums;
 pub mod lhd;
 pub mod maximin_utils;
 pub mod maxpro_utils;
+pub mod order;
 use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use maxpro::lhd::plot_x_vs_y;
 use maxpro::maximin_utils::maximin_criterion;
 use maxpro::maxpro_utils::maxpro_criterion;
 use maxpro::order::order_design;
-use rand::Rng;
 
 #[derive(Parser)]
 struct Args {
@@ -103,7 +102,7 @@ fn main() {
     println!("Swapped metric: {swap_annealed_metric}");
     println!("Annealed metric: {annealed_metric}");
 
-    let ordered_design = order_design(annealed_design, metric_fn, minimize);
+    let _ordered_design = order_design(annealed_design, metric_fn, minimize);
 
     // Plot, if requested
     if plot {

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn main() {
     println!("Swapped metric: {swap_annealed_metric}");
     println!("Annealed metric: {annealed_metric}");
 
-    let test = order_design(annealed_design, metric_fn, minimize, seed);
+    let ordered_design = order_design(annealed_design, metric_fn, minimize);
 
     // Plot, if requested
     if plot {

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,14 +102,14 @@ fn main() {
     println!("Swapped metric: {swap_annealed_metric}");
     println!("Annealed metric: {annealed_metric}");
 
-    let _ordered_design = order_design(annealed_design, metric_fn, minimize);
+    let ordered_design = order_design(annealed_design, metric_fn, minimize);
 
     // Plot, if requested
     if plot {
         if cfg!(feature = "debug") {
             if let Some(_output_path) = args.output_path {
                 #[cfg(feature = "debug")]
-                let _ = plot_x_vs_y(&annealed_design, std::path::Path::new(&_output_path));
+                let _ = plot_x_vs_y(&ordered_design, std::path::Path::new(&_output_path));
             } else {
                 eprintln!("--output-path not specified, not writing to file.")
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use maxpro::enums::Metrics;
 use maxpro::lhd::plot_x_vs_y;
 use maxpro::maximin_utils::maximin_criterion;
 use maxpro::maxpro_utils::maxpro_criterion;
+use maxpro::order::order_design;
 use rand::Rng;
 
 #[derive(Parser)]
@@ -101,6 +102,8 @@ fn main() {
     println!("Original metric: {metric_value}");
     println!("Swapped metric: {swap_annealed_metric}");
     println!("Annealed metric: {annealed_metric}");
+
+    let test = order_design(annealed_design, metric_fn, minimize, seed);
 
     // Plot, if requested
     if plot {

--- a/src/maximin_utils.rs
+++ b/src/maximin_utils.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use crate::lhd::generate_lhd;
 #[cfg(feature = "pyo3-bindings")]
 use pyo3::PyResult;
@@ -5,7 +6,9 @@ use pyo3::PyResult;
 use pyo3::exceptions::PyValueError;
 #[cfg(feature = "pyo3-bindings")]
 use pyo3::prelude::*;
+#[cfg(test)]
 use rand::SeedableRng;
+#[cfg(test)]
 use rand::rngs::StdRng;
 /// Calculate the L2 distance between two points, also known as the
 /// Euclidean distance.

--- a/src/maximin_utils.rs
+++ b/src/maximin_utils.rs
@@ -20,7 +20,7 @@ use rand::rngs::StdRng;
 /// Panics:
 ///     point_a.len() != point_b.len(): Points must have the same number of dimensions
 ///     point_a.len() == 0: Points cannot have 0 dimension
-fn calculate_l2_distance(point_a: &Vec<f64>, point_b: &Vec<f64>) -> f64 {
+pub fn calculate_l2_distance(point_a: &Vec<f64>, point_b: &Vec<f64>) -> f64 {
     assert_eq!(
         point_a.len(),
         point_b.len(),

--- a/src/maxpro_utils.rs
+++ b/src/maxpro_utils.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use crate::lhd::generate_lhd;
 #[cfg(feature = "pyo3-bindings")]
 use pyo3::PyResult;
@@ -5,7 +6,9 @@ use pyo3::PyResult;
 use pyo3::exceptions::PyValueError;
 #[cfg(feature = "pyo3-bindings")]
 use pyo3::prelude::*;
+#[cfg(test)]
 use rand::SeedableRng;
+#[cfg(test)]
 use rand::rngs::StdRng;
 use rayon::prelude::*;
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,9 +1,11 @@
+use core::f64;
+
 use crate::maximin_utils::calculate_l2_distance;
 
 /// Order designs to select an optimal subset of the full design at each
 /// stopping point. This can be used to produce preliminary results
 /// with the best available subset's design characteristics.
-pub fn order_design<F>(lhd: Vec<Vec<f64>>, metric: F, minimize: bool, seed: u64) -> Vec<Vec<f64>>
+pub fn order_design<F>(lhd: Vec<Vec<f64>>, metric: F, minimize: bool) -> Vec<Vec<f64>>
 where
     F: Fn(&Vec<Vec<f64>>) -> f64,
 {
@@ -13,23 +15,53 @@ where
     let center = vec![0.5; ndim];
     let mut center_point = lhd[0].clone();
     let mut distance_to_center = calculate_l2_distance(&center, &center_point);
+    let mut center_point_index = 0;
 
     for i in 0..n_samples {
         let proposal_distance = calculate_l2_distance(&center, &lhd[i]);
         if proposal_distance < distance_to_center {
             center_point = lhd[i].clone();
             distance_to_center = proposal_distance;
+            center_point_index = i;
         }
     }
 
-    println!("Point closest to center is {} away", distance_to_center);
-
     let mut ordered_design = vec![center_point];
+    let mut unordered_points = lhd.clone();
+    let _ = unordered_points.swap_remove(center_point_index);
 
     // Then for the remaining points, proceed in a loop
     // Attempt each point that has not been chosen
     // Find the one that produces the best metric
     // Select that point and update the design
     // Repeat
+    while !unordered_points.is_empty() {
+        let n_unordered_points = unordered_points.len();
+
+        let mut best_metric = match minimize {
+            true => f64::INFINITY,
+            false => f64::NEG_INFINITY,
+        };
+        let mut best_metric_index = 0;
+        for i in 0..n_unordered_points {
+            // There has to be a better, more efficient way to do this
+            let mut proposed_design = ordered_design.clone();
+            proposed_design.append(&mut vec![unordered_points[i].clone()]);
+            let metric_value = metric(&proposed_design);
+            if minimize {
+                if metric_value < best_metric {
+                    best_metric = metric_value;
+                    best_metric_index = i;
+                }
+            } else {
+                if metric_value > best_metric {
+                    best_metric = metric_value;
+                    best_metric_index = i;
+                }
+            }
+        }
+        let next_best_row = unordered_points.swap_remove(best_metric_index);
+        ordered_design.append(&mut vec![next_best_row.clone()]);
+    }
     ordered_design
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -19,16 +19,15 @@ where
 {
     // First: Choose middle point
     let ndim = lhd[0].len();
-    let n_samples = lhd.len();
     let center = vec![0.5; ndim];
     let mut center_point = lhd[0].clone();
     let mut distance_to_center = calculate_l2_distance(&center, &center_point);
     let mut center_point_index = 0;
 
-    for i in 0..n_samples {
-        let proposal_distance = calculate_l2_distance(&center, &lhd[i]);
+    for (i, row) in lhd.iter().enumerate() {
+        let proposal_distance = calculate_l2_distance(&center, row);
         if proposal_distance < distance_to_center {
-            center_point = lhd[i].clone();
+            center_point = row.clone();
             distance_to_center = proposal_distance;
             center_point_index = i;
         }
@@ -44,17 +43,15 @@ where
     // Select that point and update the design
     // Repeat
     while !unordered_points.is_empty() {
-        let n_unordered_points = unordered_points.len();
-
         let mut best_metric = match minimize {
             true => f64::INFINITY,
             false => f64::NEG_INFINITY,
         };
         let mut best_metric_index = 0;
-        for i in 0..n_unordered_points {
+        for (i, row) in unordered_points.iter().enumerate() {
             // There has to be a better, more efficient way to do this
             let mut proposed_design = ordered_design.clone();
-            proposed_design.append(&mut vec![unordered_points[i].clone()]);
+            proposed_design.append(&mut vec![row.clone()]);
             let metric_value = metric(&proposed_design);
             if minimize {
                 if metric_value < best_metric {

--- a/src/order.rs
+++ b/src/order.rs
@@ -5,6 +5,14 @@ use crate::maximin_utils::calculate_l2_distance;
 /// Order designs to select an optimal subset of the full design at each
 /// stopping point. This can be used to produce preliminary results
 /// with the best available subset's design characteristics.
+///
+/// Args:
+///     lhd (Vec<Vec<64>>): A design to order
+///     metric (F): A metric function that maps &Vec<Vec<f64>> to f64
+///     minimize (bool): Whether the metric is to be minimized
+///
+/// Returns:
+///     Vec<Vec<f64>>: lhd with elements reordered for optimal run order
 pub fn order_design<F>(lhd: Vec<Vec<f64>>, metric: F, minimize: bool) -> Vec<Vec<f64>>
 where
     F: Fn(&Vec<Vec<f64>>) -> f64,

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,16 +1,35 @@
-use rand::Rng;
-use rand::SeedableRng;
-use rand::rngs::StdRng;
+use crate::maximin_utils::calculate_l2_distance;
 
-/// Order designs to select an optimal subset of the full design at each 
+/// Order designs to select an optimal subset of the full design at each
 /// stopping point. This can be used to produce preliminary results
 /// with the best available subset's design characteristics.
-pub fn order_design(lhd: Vec<Vec<f64>>, metric: F, minimize: bool, seed: u64) -> Vec<Vec<f64>> {
+pub fn order_design<F>(lhd: Vec<Vec<f64>>, metric: F, minimize: bool, seed: u64) -> Vec<Vec<f64>>
+where
+    F: Fn(&Vec<Vec<f64>>) -> f64,
+{
     // First: Choose middle point
+    let ndim = lhd[0].len();
+    let n_samples = lhd.len();
+    let center = vec![0.5; ndim];
+    let mut center_point = lhd[0].clone();
+    let mut distance_to_center = calculate_l2_distance(&center, &center_point);
+
+    for i in 0..n_samples {
+        let proposal_distance = calculate_l2_distance(&center, &lhd[i]);
+        if proposal_distance < distance_to_center {
+            center_point = lhd[i].clone();
+            distance_to_center = proposal_distance;
+        }
+    }
+
+    println!("Point closest to center is {} away", distance_to_center);
+
+    let mut ordered_design = vec![center_point];
 
     // Then for the remaining points, proceed in a loop
     // Attempt each point that has not been chosen
     // Find the one that produces the best metric
     // Select that point and update the design
     // Repeat
+    ordered_design
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -69,10 +69,12 @@ where
         };
         let mut best_metric_index = 0;
         for (i, row) in unordered_points.iter().enumerate() {
-            // There has to be a better, more efficient way to do this
-            let mut proposed_design = ordered_design.clone();
-            proposed_design.append(&mut vec![row.clone()]);
-            let metric_value = metric(&proposed_design);
+            // Add the row under consideration
+            ordered_design.push(row.clone());
+            // Calculate the metric
+            let metric_value = metric(&ordered_design);
+            // Remove the candidate row
+            ordered_design.pop();
             if minimize {
                 if metric_value < best_metric {
                     best_metric = metric_value;
@@ -86,7 +88,7 @@ where
             }
         }
         let next_best_row = unordered_points.swap_remove(best_metric_index);
-        ordered_design.append(&mut vec![next_best_row.clone()]);
+        ordered_design.push(next_best_row.clone());
     }
     ordered_design
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -52,7 +52,7 @@ where
         }
     }
 
-    let mut unordered_points: Vec<Vec<f64>> = lhd.clone();
+    let mut unordered_points: Vec<Vec<f64>> = lhd;
 
     let center_point: Vec<f64> = unordered_points.swap_remove(center_point_index);
     let mut ordered_design: Vec<Vec<f64>> = Vec::new();
@@ -127,15 +127,15 @@ fn test_ordered_criteria_parity() {
     }
 }
 
-#[cfg(feature = "pyo3-bindings")] // WORK IN PROGRESS
+#[cfg(feature = "pyo3-bindings")]
 /// Order the design to optimize the run order for optimal subset ordering
 ///
 /// Args:
 ///     design (list[list[float]]): Design of interest
-///     metric_name (str):
+///     metric_name (str): Name of the metric of interest, one of ("maximin", "maxpro")
 ///
 /// Returns:
-///     float: Maximum projection criterion value
+///     list[list[float]]: Optimally-reordered design
 #[pyfunction(name = "order_design")]
 pub fn py_order_design(design: Vec<Vec<f64>>, metric_name: String) -> PyResult<Vec<Vec<f64>>> {
     if design.is_empty() {

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,6 +1,13 @@
-use core::f64;
-
 use crate::maximin_utils::calculate_l2_distance;
+use crate::maximin_utils::maximin_criterion;
+use crate::maxpro_utils::maxpro_criterion;
+use core::f64;
+#[cfg(feature = "pyo3-bindings")]
+use pyo3::PyResult;
+#[cfg(feature = "pyo3-bindings")]
+use pyo3::exceptions::PyValueError;
+#[cfg(feature = "pyo3-bindings")]
+use pyo3::prelude::*;
 
 /// Order designs to select an optimal subset of the full design at each
 /// stopping point. This can be used to produce preliminary results
@@ -69,4 +76,33 @@ where
         ordered_design.append(&mut vec![next_best_row.clone()]);
     }
     ordered_design
+}
+
+#[cfg(feature = "pyo3-bindings")] // WORK IN PROGRESS
+/// Order the design to optimize the run order for optimal subset ordering
+///
+/// Args:
+///     design (list[list[float]]): Design of interest
+///     metric_name (str):
+///
+/// Returns:
+///     float: Maximum projection criterion value
+#[pyfunction(name = "order_design")]
+pub fn py_order_design(design: Vec<Vec<f64>>, metric_name: String) -> PyResult<Vec<Vec<f64>>> {
+    if design.is_empty() {
+        return Err(PyValueError::new_err("Design cannot be empty"));
+    }
+    // Note: The `as` here is required for this to compile as the match arms having different
+    // functions causes compilation errors despite matching signatures
+    let (metric, minimize) = match metric_name.to_lowercase().as_str() {
+        "maxpro" => (maxpro_criterion as fn(&Vec<Vec<f64>>) -> f64, true),
+        "maximin" => (maximin_criterion as fn(&Vec<Vec<f64>>) -> f64, false),
+        _ => {
+            return Err(PyValueError::new_err(format!(
+                "Unknown metric: '{}'. Available metrics are 'maxpro' and 'maximin'.",
+                metric_name
+            )));
+        }
+    };
+    Ok(order_design(design, metric, minimize))
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -34,7 +34,6 @@ where
     F: Fn(&Vec<Vec<f64>>) -> f64,
 {
     if lhd.is_empty() {
-        println!("Cannot order an empty design!");
         return lhd;
     }
     // First: Choose middle point

--- a/src/order.rs
+++ b/src/order.rs
@@ -88,7 +88,7 @@ where
             }
         }
         let next_best_row = unordered_points.swap_remove(best_metric_index);
-        ordered_design.push(next_best_row.clone());
+        ordered_design.push(next_best_row);
     }
     ordered_design
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -69,13 +69,17 @@ where
             false => f64::NEG_INFINITY,
         };
         let mut best_metric_index = 0;
-        for (i, row) in unordered_points.iter().enumerate() {
-            // Add the row under consideration
-            ordered_design.push(row.clone());
+        for (i, row_ref) in unordered_points.iter_mut().enumerate() {
+            // Add the row under consideration, taking it from the original Vec
+            let row = std::mem::take(row_ref);
+            ordered_design.push(row);
             // Calculate the metric
             let metric_value = metric(&ordered_design);
             // Remove the candidate row
-            ordered_design.pop();
+            let row = ordered_design.pop().unwrap();
+            // Assign old value back to the original location in memory
+            *row_ref = row;
+
             if minimize {
                 if metric_value < best_metric {
                     best_metric = metric_value;

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,3 +1,4 @@
+use crate::lhd::generate_lhd;
 use crate::maximin_utils::calculate_l2_distance;
 use crate::maximin_utils::maximin_criterion;
 use crate::maxpro_utils::maxpro_criterion;
@@ -8,6 +9,11 @@ use pyo3::PyResult;
 use pyo3::exceptions::PyValueError;
 #[cfg(feature = "pyo3-bindings")]
 use pyo3::prelude::*;
+use std::f32::EPSILON;
+
+#[cfg(test)]
+use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 /// Order designs to select an optimal subset of the full design at each
 /// stopping point. This can be used to produce preliminary results
@@ -76,6 +82,39 @@ where
         ordered_design.append(&mut vec![next_best_row.clone()]);
     }
     ordered_design
+}
+
+#[test]
+/// Test that the LHD has the same metric values before and after ordering
+fn test_ordered_criteria_parity() {
+    let n_iterations: u64 = 1000;
+    let n_samples: u64 = 50;
+    let n_dim: u64 = 5;
+    let seed: u64 = 12345;
+    let atol: f64 = 1e-10;
+
+    let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
+    for _i in 0..n_iterations {
+        // Generate LHD
+        let lhd = generate_lhd(n_samples, n_dim, &mut rng);
+        let maxpro_metric_before: f64 = maxpro_criterion(&lhd);
+        let maximin_metric_before: f64 = maximin_criterion(&lhd);
+
+        // Order Design
+        let ordered_design = order_design(lhd, maximin_criterion, true);
+
+        // Ensure parity
+        let maxpro_metric_after: f64 = maxpro_criterion(&ordered_design);
+        let maximin_metric_after: f64 = maximin_criterion(&ordered_design);
+
+        assert!(maxpro_metric_after >= 0.0);
+        assert!(maxpro_metric_after < f64::INFINITY);
+        assert!(maximin_metric_after >= 0.0);
+        assert!(maximin_metric_after < f64::INFINITY);
+
+        assert!((maximin_metric_before - maximin_metric_after).abs() < atol);
+        assert!((maxpro_metric_before - maxpro_metric_after).abs() < atol);
+    }
 }
 
 #[cfg(feature = "pyo3-bindings")] // WORK IN PROGRESS

--- a/src/order.rs
+++ b/src/order.rs
@@ -22,6 +22,8 @@ use rand::rngs::StdRng;
 /// stopping point. This can be used to produce preliminary results
 /// with the best available subset's design characteristics.
 ///
+/// This is presently only designed for unit hypercube designs.
+///
 /// Args:
 ///     lhd (Vec<Vec<f64>>): A design to order
 ///     metric (F): A metric function that maps &Vec<Vec<f64>> to f64
@@ -147,7 +149,8 @@ fn test_empty_vecs() {
 }
 
 #[cfg(feature = "pyo3-bindings")]
-/// Order the design to optimize the run order for optimal subset ordering
+/// Order the design to optimize the run order for optimal subset ordering.
+/// This is currently only for unit hypercube designs.
 ///
 /// Args:
 ///     design (list[list[float]]): Design of interest
@@ -158,7 +161,7 @@ fn test_empty_vecs() {
 #[pyfunction(name = "order_design")]
 pub fn py_order_design(design: Vec<Vec<f64>>, metric_name: String) -> PyResult<Vec<Vec<f64>>> {
     if design.is_empty() {
-        return Err(PyValueError::new_err("Design cannot be empty"));
+        return Ok(design);
     }
     // Note: The `as` here is required for this to compile as the match arms having different
     // functions causes compilation errors despite matching signatures

--- a/src/order.rs
+++ b/src/order.rs
@@ -38,6 +38,10 @@ where
     }
     // First: Choose middle point
     let ndim: usize = lhd[0].len();
+    if ndim == 0 {
+        // Happens when vec![vec![]] is passed
+        return lhd;
+    }
     // Note: This assumes the design space is always a unit hypercube.
     // This is currently true, but must be updated if the condition is relaxed.
     let center: Vec<f64> = vec![0.5; ndim];
@@ -129,6 +133,17 @@ fn test_ordered_criteria_parity() {
         assert!((maximin_metric_before - maximin_metric_after).abs() < atol);
         assert!((maxpro_metric_before - maxpro_metric_after).abs() < atol);
     }
+}
+
+#[test]
+/// Test that empty inner points are handled
+fn test_empty_vecs() {
+    let lhd = vec![vec![]];
+    let ordered_lhd_minimize = order_design(lhd.clone(), maxpro_criterion, true);
+    let ordered_lhd_maximize = order_design(lhd.clone(), maxpro_criterion, false);
+
+    assert_eq!(lhd, ordered_lhd_minimize);
+    assert_eq!(lhd, ordered_lhd_maximize);
 }
 
 #[cfg(feature = "pyo3-bindings")]

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,0 +1,16 @@
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+/// Order designs to select an optimal subset of the full design at each 
+/// stopping point. This can be used to produce preliminary results
+/// with the best available subset's design characteristics.
+pub fn order_design(lhd: Vec<Vec<f64>>, metric: F, minimize: bool, seed: u64) -> Vec<Vec<f64>> {
+    // First: Choose middle point
+
+    // Then for the remaining points, proceed in a loop
+    // Attempt each point that has not been chosen
+    // Find the one that produces the best metric
+    // Select that point and update the design
+    // Repeat
+}

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,6 +1,9 @@
+#[cfg(test)]
 use crate::lhd::generate_lhd;
 use crate::maximin_utils::calculate_l2_distance;
+#[cfg(any(test, feature = "pyo3-bindings"))]
 use crate::maximin_utils::maximin_criterion;
+#[cfg(any(test, feature = "pyo3-bindings"))]
 use crate::maxpro_utils::maxpro_criterion;
 use core::f64;
 #[cfg(feature = "pyo3-bindings")]
@@ -9,10 +12,10 @@ use pyo3::PyResult;
 use pyo3::exceptions::PyValueError;
 #[cfg(feature = "pyo3-bindings")]
 use pyo3::prelude::*;
-use std::f32::EPSILON;
 
 #[cfg(test)]
 use rand::SeedableRng;
+#[cfg(test)]
 use rand::rngs::StdRng;
 
 /// Order designs to select an optimal subset of the full design at each

--- a/src/order.rs
+++ b/src/order.rs
@@ -37,24 +37,26 @@ where
         return lhd;
     }
     // First: Choose middle point
-    let ndim = lhd[0].len();
-    let center = vec![0.5; ndim];
-    let mut center_point = lhd[0].clone();
-    let mut distance_to_center = calculate_l2_distance(&center, &center_point);
-    let mut center_point_index = 0;
+    let ndim: usize = lhd[0].len();
+    // Note: This assumes the design space is always a unit hypercube.
+    // This is currently true, but must be updated if the condition is relaxed.
+    let center: Vec<f64> = vec![0.5; ndim];
+    let mut distance_to_center: f64 = f64::INFINITY;
+    let mut center_point_index: usize = 0;
 
     for (i, row) in lhd.iter().enumerate() {
-        let proposal_distance = calculate_l2_distance(&center, row);
+        let proposal_distance: f64 = calculate_l2_distance(&center, row);
         if proposal_distance < distance_to_center {
-            center_point = row.clone();
             distance_to_center = proposal_distance;
             center_point_index = i;
         }
     }
 
-    let mut ordered_design = vec![center_point];
-    let mut unordered_points = lhd.clone();
-    let _ = unordered_points.swap_remove(center_point_index);
+    let mut unordered_points: Vec<Vec<f64>> = lhd.clone();
+
+    let center_point: Vec<f64> = unordered_points.swap_remove(center_point_index);
+    let mut ordered_design: Vec<Vec<f64>> = Vec::new();
+    ordered_design.push(center_point);
 
     // Then for the remaining points, proceed in a loop
     // Attempt each point that has not been chosen
@@ -62,7 +64,7 @@ where
     // Select that point and update the design
     // Repeat
     while !unordered_points.is_empty() {
-        let mut best_metric = match minimize {
+        let mut best_metric: f64 = match minimize {
             true => f64::INFINITY,
             false => f64::NEG_INFINITY,
         };
@@ -86,7 +88,7 @@ where
                 }
             }
         }
-        let next_best_row = unordered_points.swap_remove(best_metric_index);
+        let next_best_row: Vec<f64> = unordered_points.swap_remove(best_metric_index);
         ordered_design.push(next_best_row);
     }
     ordered_design

--- a/src/order.rs
+++ b/src/order.rs
@@ -23,7 +23,7 @@ use rand::rngs::StdRng;
 /// with the best available subset's design characteristics.
 ///
 /// Args:
-///     lhd (Vec<Vec<64>>): A design to order
+///     lhd (Vec<Vec<f64>>): A design to order
 ///     metric (F): A metric function that maps &Vec<Vec<f64>> to f64
 ///     minimize (bool): Whether the metric is to be minimized
 ///
@@ -33,6 +33,10 @@ pub fn order_design<F>(lhd: Vec<Vec<f64>>, metric: F, minimize: bool) -> Vec<Vec
 where
     F: Fn(&Vec<Vec<f64>>) -> f64,
 {
+    if lhd.is_empty() {
+        println!("Cannot order an empty design!");
+        return lhd;
+    }
     // First: Choose middle point
     let ndim = lhd[0].len();
     let center = vec![0.5; ndim];
@@ -104,7 +108,7 @@ fn test_ordered_criteria_parity() {
         let maximin_metric_before: f64 = maximin_criterion(&lhd);
 
         // Order Design
-        let ordered_design = order_design(lhd, maximin_criterion, true);
+        let ordered_design = order_design(lhd, maximin_criterion, false);
 
         // Ensure parity
         let maxpro_metric_after: f64 = maxpro_criterion(&ordered_design);


### PR DESCRIPTION
**Description:** Add functionality to order designs, ensuring an incomplete run of a computer experiment using the design is the optimal incomplete subset.

The approach taken is to first find the point closest to the middle, e.g. (0.5, 0.5, ...). Then, each point not yet in the design is considered and the metric is calculated, the point that minimizes (or maximizes) the design is retained.

The intention is for this to be the final feature upgrade before 0.1.2, leaving the following features from the R package not implemented:
- Augmentation of designs with additional points (plan: 0.1.3)
- Quantitative and Qualitative factors

Qualitative factors are a significant lift to add in, so those will be for a future version. This crate/package will then be nearing feature completion vs. the R implementation as well as having the ability to improve any other design calculation that can be implemented.

Development status: 
- [x] Selecting the centerpoint
- [x] Selecting subsequent points
- [ ] ~Parallelization using rayon (not necessary yet, calculation is straightforward)~
- [x] Python bindings
- [x] Tests in Rust
- [x] Benchmarks and example in Python
- [x] Documentation updates
- [x] ReadMe updates

Extra bonus:
- Resolved a bunch of clippy import errors 

**Testing:**
Ran tests, ordered, ran a few benchmarks from Python

**Impacts:**
- [x] Rust
- [x] Python
