### PR TITLE
Bump pyo3 to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.3"
 optional = true
 
 [dependencies.pyo3]
-version = "0.27" 
+version = "0.29"
 optional = true 
 features = ["extension-module"]
 


### PR DESCRIPTION
**Description:**
 Bump PyO3 to 0.29 to resolve known security issues

**Testing:**
Unit tests + python benchmarks

**Impacts:**
- [ ] Rust
- [x] Python
